### PR TITLE
update links to official wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,7 +673,7 @@
             - [Learn X in Y minutes, where X=nix](https://learnxinyminutes.com/docs/nix/)
             - [A tour of Nix](https://nixcloud.io/tour/)
               - By Joachim Schiele & Paul Seitz from Tübingen ;)
-            - [Unofficial user's wiki](https://nixos.wiki/wiki/Main_Page)
+            - [Official user's wiki](https://wiki.nixos.org/wiki/Main_Page)
             - Manuals
                 ([Nix](https://nixos.org/nix/manual/),
                 [Nixpkgs](https://nixos.org/nixpkgs/manual/),

--- a/lightning-talk.html
+++ b/lightning-talk.html
@@ -537,7 +537,7 @@
             - [Learn X in Y minutes, where X=nix](https://learnxinyminutes.com/docs/nix/)
             - [A tour of Nix](https://nixcloud.io/tour/)
               - By Joachim Schiele & Paul Seitz from Tübingen ;)
-            - [Unofficial user's wiki](https://nixos.wiki/wiki/Main_Page)
+            - [Official user's wiki](https://wiki.nixos.org/wiki/Main_Page)
             - Manuals
                 ([Nix](https://nixos.org/nix/manual/),
                 [Nixpkgs](https://nixos.org/nixpkgs/manual/),


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org
ref: NixOS/foundation#113